### PR TITLE
Use workflow ID on Circle CI

### DIFF
--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -60,7 +60,7 @@ module Coveralls
 
     def self.set_service_params_for_circleci(config)
       config[:service_name]         = 'circleci'
-      config[:service_number]       = ENV['CIRCLE_BUILD_NUM']
+      config[:service_number]       = ENV['CIRCLE_WORKFLOW_ID']
       config[:service_pull_request] = (ENV['CI_PULL_REQUEST'] || "")[/(\d+)$/,1]
       config[:parallel]             = ENV['CIRCLE_NODE_TOTAL'].to_i > 1
       config[:service_job_number]   = ENV['CIRCLE_NODE_INDEX']
@@ -207,7 +207,8 @@ module Coveralls
           {
             :circleci_build_num => ENV['CIRCLE_BUILD_NUM'],
             :branch => ENV['CIRCLE_BRANCH'],
-            :commit_sha => ENV['CIRCLE_SHA1']
+            :commit_sha => ENV['CIRCLE_SHA1'],
+            :circle_workflow_id => ENV['CIRCLE_WORKFLOW_ID'],
           }
         elsif ENV['JENKINS_URL']
           {


### PR DESCRIPTION
Workflow ID is the same across all the jobs being run so this should hopefully mean that the coverage data is combined instead of being displayed separately when there a multiple job that report coverage information.

Unfortunately this ID is a UUID. Using pipeline variables might be a better option? https://circleci.com/docs/2.0/pipeline-variables/

You can see this in action with [rufo](https://coveralls.io/repos/286792/builds).

Perhaps unrelated but it is reporting changes in coverage when rerunning the same workflow. I suspect that it is depending on which job is reporting first?
<img width="811" alt="Screen Shot 2020-01-12 at 8 46 00 PM" src="https://user-images.githubusercontent.com/1177034/72224621-b3fadb00-357c-11ea-9fac-7d1983b423ff.png">
